### PR TITLE
Bump describe instance timeout

### DIFF
--- a/bouncer/runner.go
+++ b/bouncer/runner.go
@@ -51,8 +51,8 @@ type BaseRunner struct {
 const (
 	waitBetweenChecks = 15 * time.Second
 	// Sleep time and number of times to retry non-destructive AWS API calls
-	apiRetryCount = 5
-	apiRetrySleep = 1 * time.Second
+	apiRetryCount = 10
+	apiRetrySleep = 3 * time.Second
 
 	asgSeparator        = ","
 	desiredCapSeparator = ":"


### PR DESCRIPTION
I hit this twice today in two different accounts after not hitting it for months.  It just was taking the EC2 API a bit longer than usual today, so give ourselves 30s instead of 5s of breathing room to let the ec2 api catch up