### PR TITLE
Remove failure if new unhealthy nodes exist on start

### DIFF
--- a/canary/runner.go
+++ b/canary/runner.go
@@ -85,18 +85,6 @@ func (r *Runner) MustValidatePrereqs() {
 			}).Error("Desired capacity given must be less than or equal to 2x max_size")
 			os.Exit(1)
 		}
-
-		if asgSet.IsNewUnhealthy() {
-			for _, inst := range asgSet.GetUnhealthyNewInstances() {
-				log.WithFields(log.Fields{
-					"ASG":                 *actualAsg.ASG.AutoScalingGroupName,
-					"Instance ID":         *inst.EC2Instance.InstanceId,
-					"EC2 State":           *inst.EC2Instance.State.Name,
-					"ASG Lifecycle State": *inst.ASGInstance.LifecycleState,
-				}).Error("Instance is new and unhealthy")
-			}
-			os.Exit(1)
-		}
 	}
 }
 


### PR DESCRIPTION
It's happened to me fairly often that a TF apply has timed-out because a node was unhealthy for some external reason.  I fix the external reason, and just want bouncer to continue waiting for the new instance to come up and then continue.  However, currently, it bails out immediately when you start it in the fashion, so I have to wait for that one instance to become healthy, and only then kick-off the TF apply to re-run.

I'm not sure why we need this precondition, as without it, bouncer will just immediately start-up in a "waiting for instance to become healthy" state, which seems just fine.