### PR TITLE
Space-out API retries

### DIFF
--- a/bouncer/instance.go
+++ b/bouncer/instance.go
@@ -43,7 +43,7 @@ func NewInstance(ac *aws.Clients, asg *autoscaling.Group, asgInst *autoscaling.I
 		return
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error converting ASG Inst to EC2 inst for %s", *asgInst.InstanceId)
+		return nil, errors.Wrapf(err, "error converting ASG Inst to EC2 inst for %s", *asgInst.InstanceId)
 	}
 
 	inst := Instance{

--- a/bouncer/runner.go
+++ b/bouncer/runner.go
@@ -52,7 +52,7 @@ const (
 	waitBetweenChecks = 15 * time.Second
 	// Sleep time and number of times to retry non-destructive AWS API calls
 	apiRetryCount = 10
-	apiRetrySleep = 3 * time.Second
+	apiRetrySleep = 10 * time.Second
 
 	asgSeparator        = ","
 	desiredCapSeparator = ":"


### PR DESCRIPTION
The error converting ASG Inst to EC2 inst for error has fired in one of our accounts a couple of times the last couple weeks, and both times it was just a timing issue, so let's extend how long we keep trying for