### PR TITLE
Refactor to handle nil case for asg launch template version

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -111,21 +111,28 @@ func (c Clients) ASGLTplVersionToEC2LTplVersion(asgLaunchTemplate *autoscaling.L
 		return nil, errors.New("More than 1 LaunchTemplate found somehow")
 	}
 
-	for _, ec2LaunchTemplate := range res.LaunchTemplates {
-		switch version := *asgLaunchTemplate.Version; version {
-		case "$Latest":
-			s := strconv.FormatInt(*ec2LaunchTemplate.LatestVersionNumber, 10)
-			return &s, nil
-		case "$Default":
-			s := strconv.FormatInt(*ec2LaunchTemplate.DefaultVersionNumber, 10)
-			return &s, nil
-		default:
-			_, err := strconv.ParseInt(version, 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("Unexpected TemplateVersion %q conversion to Int64 failed", version)
-			}
-			return &version, nil
-		}
+	if len(res.LaunchTemplates) == 0 {
+		return nil, errors.Wrapf(err, "LaunchTemplate %s not found", *asgLaunchTemplate.LaunchTemplateId)
 	}
-	return nil, errors.Wrapf(err, "LaunchTemplate %s not found", *asgLaunchTemplate.LaunchTemplateId)
+
+	ec2LaunchTemplate := res.LaunchTemplates[0]
+
+	targetVersion := asgLaunchTemplate.Version
+
+	// Per https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_LaunchTemplateSpecification.html
+	// version is optional and if unspecified should resolve to default.
+	if targetVersion == nil || *targetVersion == "$Default" {
+		s := strconv.FormatInt(*ec2LaunchTemplate.DefaultVersionNumber, 10)
+		return &s, nil
+	} else if *targetVersion == "$Latest" {
+		s := strconv.FormatInt(*ec2LaunchTemplate.LatestVersionNumber, 10)
+		return &s, nil
+	} else {
+		_, err := strconv.ParseInt(*targetVersion, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("Unexpected TemplateVersion %q conversion to Int64 failed", *targetVersion)
+		}
+		return targetVersion, nil
+	}
+
 }

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -107,12 +107,13 @@ func (c Clients) ASGLTplVersionToEC2LTplVersion(asgLaunchTemplate *autoscaling.L
 		return nil, errors.Wrapf(err, "Error describing LaunchTemplate %s", *asgLaunchTemplate.LaunchTemplateId)
 	}
 
-	if len(res.LaunchTemplates) > 1 {
-		return nil, errors.New("More than 1 LaunchTemplate found somehow")
-	}
-
-	if len(res.LaunchTemplates) == 0 {
-		return nil, errors.Wrapf(err, "LaunchTemplate %s not found", *asgLaunchTemplate.LaunchTemplateId)
+	if len(res.LaunchTemplates) != 1 {
+		return nil, errors.Wrapf(err,
+			"Expected exactly one LaunchTemplate returned for launch template id %s, got %d: %v",
+			*asgLaunchTemplate.LaunchTemplateId,
+			len(res.LaunchTemplates),
+			res.LaunchTemplates,
+		)
 	}
 
 	ec2LaunchTemplate := res.LaunchTemplates[0]


### PR DESCRIPTION
Launch Template version in the autoscaling group specification can be
nil; when nil it should match the behavior of default. Instead of
copypasta, refactored the switch out into if/else behavior for
clarity.

NB: I've sat down and tried to create an ASG that replicates the behavior we saw in production and can't find a way to generate an ASG with a template specification with no Version set; this may have largely been remediated in AWS API land. Still feels worth papering over properly to me, but I'm okay if you'd rather not.


Error we saw:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa932db]

goroutine 1 [running]:
github.com/palantir/bouncer/aws.Clients.ASGLTplVersionToEC2LTplVersion(0xc00000c1d8, 0xc00000c1e8, 0xc00058a220, 0xc000352000, 0x0, 0x0)
	/go/src/github.com/palantir/bouncer/aws/aws.go:115 +0x12b
github.com/palantir/bouncer/bouncer.NewInstance.func2(0x0, 0x0)
	/go/src/github.com/palantir/bouncer/bouncer/instance.go:53 +0x4c
github.com/palantir/bouncer/bouncer.retry(0xa, 0x2540be400, 0xc0003c3420, 0x0, 0x0)
	/go/src/github.com/palantir/bouncer/bouncer/runner.go:68 +0x7f
github.com/palantir/bouncer/bouncer.NewInstance(0xc0002f12a0, 0xc000418160, 0xc000135e40, 0x0, 0xbf58602c40d03a9e, 0x326b2d, 0x14fbb20, 0x0, 0x1, 0x1, ...)
	/go/src/github.com/palantir/bouncer/bouncer/instance.go:52 +0x15c
github.com/palantir/bouncer/bouncer.NewASG(0xc0002f12a0, 0xc00031c960, 0x0, 0xbf58602c40d03a9e, 0x326b2d, 0x14fbb20, 0xc0002f12a0, 0x0, 0x14fc640)
	/go/src/github.com/palantir/bouncer/bouncer/asg.go:48 +0x1a9
github.com/palantir/bouncer/bouncer.newASGSet(0xc0002f12a0, 0xc00000c1f0, 0x1, 0x1, 0xc0002f1200, 0xbf58602c40d03a9e, 0x326b2d, 0x14fbb20, 0x20, 0x20, ...)
	/go/src/github.com/palantir/bouncer/bouncer/asgset.go:37 +0xcb
github.com/palantir/bouncer/bouncer.(*BaseRunner).NewASGSet(0xc00001d920, 0x8, 0xc00031c940, 0xc00031c960)
	/go/src/github.com/palantir/bouncer/bouncer/runner.go:260 +0x74
github.com/palantir/bouncer/serial.(*Runner).MustValidatePrereqs(0xc00001d920)
	/go/src/github.com/palantir/bouncer/serial/runner.go:52 +0x63
github.com/palantir/bouncer/cmd.glob..func4(0x14f2fe0, 0xc000135c40, 0x0, 0x4)
	/go/src/github.com/palantir/bouncer/cmd/serial.go:74 +0x4c4
github.com/palantir/bouncer/vendor/github.com/spf13/cobra.(*Command).execute(0x14f2fe0, 0xc000135b80, 0x4, 0x4, 0x14f2fe0, 0xc000135b80)
	/go/src/github.com/palantir/bouncer/vendor/github.com/spf13/cobra/command.go:648 +0x244
github.com/palantir/bouncer/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x14f2dc0, 0x0, 0x0, 0x0)
	/go/src/github.com/palantir/bouncer/vendor/github.com/spf13/cobra/command.go:734 +0x2cc
github.com/palantir/bouncer/vendor/github.com/spf13/cobra.(*Command).Execute(0x14f2dc0, 0xc0002f0920, 0xc000207f50)
	/go/src/github.com/palantir/bouncer/vendor/github.com/spf13/cobra/command.go:693 +0x2b
github.com/palantir/bouncer/cmd.Execute()
	/go/src/github.com/palantir/bouncer/cmd/root.go:63 +0x2d
main.main()
	/go/src/github.com/palantir/bouncer/main/main.go:25 +0x62
```