### PR TITLE
Create rolling runner option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ If you need to run serial mode against an ASG with an expected `desired_capacity
 ./bouncer serial -a hashi-use1-stag-worker-linux:3,hashi-use1-stag-worker-windows:2
 ```
 
+## Rolling
+
+Rolling is the same as serial, but does not decrement. This means `min_size`, `max_size`, and `desired_capacity` can all be the same value.
+
 ## Canary
 
 Made for bouncing ASGs of arbitrary size where additional nodes and scale in before the old nodes have scaled out.  `./bouncer canary --help` for all available options.  Ex:

--- a/aws/asg.go
+++ b/aws/asg.go
@@ -135,13 +135,10 @@ func (c *Clients) CompleteLifecycleAction(asgName *string, instID *string, lifec
 }
 
 // TerminateInstanceInASG calls https://docs.aws.amazon.com/cli/latest/reference/autoscaling/terminate-instance-in-auto-scaling-group.html
-func (c *Clients) TerminateInstanceInASG(instID *string) error {
-	// This call decrements the desired capacity so that we don't get into a race condition
-	// where the replacement starts booting before the node we've told to terminate has terminated
-	dumb := true
+func (c *Clients) TerminateInstanceInASG(instID *string, decrement *bool) error {
 	input := autoscaling.TerminateInstanceInAutoScalingGroupInput{
 		InstanceId:                     instID,
-		ShouldDecrementDesiredCapacity: &dumb,
+		ShouldDecrementDesiredCapacity: decrement,
 	}
 	_, err := c.ASGClient.TerminateInstanceInAutoScalingGroup(&input)
 	return errors.Wrapf(err, "error terminating instance %s", *instID)

--- a/bouncer/runner.go
+++ b/bouncer/runner.go
@@ -153,7 +153,7 @@ func (r *BaseRunner) abandonLifecycle(inst *Instance, hook *string) error {
 
 // KillInstance calls TerminateInstanceInAutoscalingGroup, or, if the instance is stuck
 // in a lifecycle hook, issues an ABANDON to it, killing it more forcefully
-func (r *BaseRunner) KillInstance(inst *Instance) error {
+func (r *BaseRunner) KillInstance(inst *Instance, decrement *bool) error {
 	log.WithFields(log.Fields{
 		"ASG":        *inst.AutoscalingGroup.AutoScalingGroupName,
 		"InstanceID": *inst.ASGInstance.InstanceId,
@@ -179,18 +179,18 @@ func (r *BaseRunner) KillInstance(inst *Instance) error {
 			return errors.Wrap(err, "error executing pre-terminate command")
 		}
 	}
-	err := r.terminateInstanceInASG(inst)
+	err := r.terminateInstanceInASG(inst, decrement)
 	return errors.Wrap(err, "error terminating instance")
 }
 
-func (r *BaseRunner) terminateInstanceInASG(inst *Instance) error {
+func (r *BaseRunner) terminateInstanceInASG(inst *Instance, decrement *bool) error {
 	log.WithFields(log.Fields{
 		"ASG":        *inst.AutoscalingGroup.AutoScalingGroupName,
 		"InstanceID": *inst.ASGInstance.InstanceId,
 	}).Info("Terminating instance")
 	r.resetTimeout()
 	r.noopCheck()
-	return r.awsClients.TerminateInstanceInASG(inst.ASGInstance.InstanceId)
+	return r.awsClients.TerminateInstanceInASG(inst.ASGInstance.InstanceId, decrement)
 }
 
 // SetDesiredCapacity Updates desired capacity of ASG

--- a/canary/runner.go
+++ b/canary/runner.go
@@ -153,8 +153,9 @@ func (r *Runner) Run() error {
 			// We have the correct number of new instances, we just need
 			// to get rid of the old ones
 			// Let's issue all their terminates right here
+			decrement := true
 			for _, oldInst := range asgSet.GetOldInstances() {
-				err := r.KillInstance(oldInst)
+				err := r.KillInstance(oldInst, &decrement)
 				if err != nil {
 					return errors.Wrap(err, "error killing instance")
 				}

--- a/cmd/rolling.go
+++ b/cmd/rolling.go
@@ -1,0 +1,108 @@
+// Copyright 2017 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/palantir/bouncer/bouncer"
+	"github.com/palantir/bouncer/rolling"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var rollingCmd = &cobra.Command{
+	Use:   "rolling",
+	Short: "Run bouncer in rolling",
+	Long:  `Run bouncer in rolling mode, where we bounce one node at a time from the list of ASGs.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.SetLevel(logLevelFromViper())
+
+		log.Debug("rolling called")
+		if log.GetLevel() == log.DebugLevel {
+			cmd.DebugFlags()
+			viper.Debug()
+		}
+
+		asgsString := viper.GetString("rolling.asgs")
+		if asgsString == "" {
+			log.Fatal("You must specify ASGs to cycle nodes from (in a comma-delimited list)")
+		}
+
+		commandString := viper.GetString("rolling.command")
+		noop := viper.GetBool("rolling.noop")
+		force := viper.GetBool("rolling.force")
+		termHook := viper.GetString("terminate-hook")
+		pendHook := viper.GetString("pending-hook")
+		timeout := timeoutFromViper()
+
+		log.Debugf("Binding vars, got %+v %+v %+v %+v", asgsString, noop, version, commandString)
+
+		log.Info("Beginning bouncer rolling run")
+
+		var defCap int64
+		defCap = 1
+		opts := bouncer.RunnerOpts{
+			Noop:            noop,
+			Force:           force,
+			AsgString:       asgsString,
+			CommandString:   commandString,
+			DefaultCapacity: &defCap,
+			TerminateHook:   termHook,
+			PendingHook:     pendHook,
+			ItemTimeout:     timeout,
+		}
+
+		r, err := rolling.NewRunner(&opts)
+		if err != nil {
+			log.Fatal(errors.Wrap(err, "error initializing runner"))
+		}
+
+		r.MustValidatePrereqs()
+
+		err = r.Run()
+		if err != nil {
+			log.Fatal(errors.Wrap(err, "error in run"))
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(rollingCmd)
+
+	rollingCmd.Flags().BoolP("noop", "n", false, "Run this in noop mode, and only print what you would do")
+	err := viper.BindPFlag("rolling.noop", rollingCmd.Flags().Lookup("noop"))
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "Binding PFlag 'noop' to viper var 'rolling.noop' failed: %s"))
+	}
+
+	rollingCmd.Flags().StringP("asgs", "a", "", "ASGs to check for nodes to cycle in")
+	err = viper.BindPFlag("rolling.asgs", rollingCmd.Flags().Lookup("asgs"))
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "Binding PFlag 'asgs' to viper var 'rolling.asgs' failed: %s"))
+	}
+
+	rollingCmd.Flags().StringP("preterminatecall", "p", "", "External command to run before host is removed from its ELB & terminate process begins")
+	err = viper.BindPFlag("rolling.command", rollingCmd.Flags().Lookup("preterminatecall"))
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "Binding PFlag 'command' to viper var 'rolling.command' failed: %s"))
+	}
+
+	rollingCmd.Flags().BoolP("force", "f", false, "Force all nodes to be recycled, even if they're running the latest launch config")
+	err = viper.BindPFlag("rolling.force", rollingCmd.Flags().Lookup("force"))
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "Binding PFlag 'force' to viper var 'rolling.force' failed: %s"))
+	}
+}

--- a/full/runner.go
+++ b/full/runner.go
@@ -125,7 +125,8 @@ start:
 			set := asgSetWrapper(asg)
 
 			if set.IsOldInstance() {
-				err := r.KillInstance(set.GetBestOldInstance())
+				decrement := true
+				err := r.KillInstance(set.GetBestOldInstance(), &decrement)
 				if err != nil {
 					return errors.Wrap(err, "failed to kill instance")
 				}


### PR DESCRIPTION
We are using this internally at my company with our own nomad cluster. We have frontend services in the cluster, and found that neither serial nor canary worked quite the way we were hoping. I am opening this up in case it might be useful since it would be nice not to have an internal fork to maintain.

We disable node eligibility on the nodes we're about to roll, so we aren't wasting time moving allocations to nodes that are about to be rolled by this tool. This means we need a new node to be created before terminating the existing one to gracefully migrate the allocations.