### PR TITLE
Update circle tag detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /^[0-9]+(\.[0-9]+)+(-rc[0-9]+)?(-alpha[0-9]+)?$/
+              only: /^v?[0-9]+\.[0-9]+\.[0-9]+$/
             branches:
               ignore: /.*/
       - changelog:


### PR DESCRIPTION
Allow a leading v. Just made this match tag validation we use elsewhere