### PR TITLE
fix: invalid policy-bot reference

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -7,7 +7,7 @@ policy:
       - two admins have approved
       - changelog only and contributor approval
       - fixing excavator
-      - excavator only touched baseline, circle, gradle files, godel files, docker-compose-rule config or versions.props
+      - excavator only touched baseline, circle, gradle files, godel files, go dependencies, docker-compose-rule config or versions.props
       - excavator only touched config files
       - bots updated package.json and lock files
   disapproval:


### PR DESCRIPTION
The automated pull request template was missing the updated reference at the top.
