### PR TITLE
Don't sleep between canary terminates

### DIFF
--- a/canary/runner.go
+++ b/canary/runner.go
@@ -159,8 +159,8 @@ func (r *Runner) Run() error {
 				if err != nil {
 					return errors.Wrap(err, "error killing instance")
 				}
-				r.Sleep()
 			}
+			r.Sleep()
 
 			continue
 		}


### PR DESCRIPTION
Instead, sleep only after you've sent-off _all_ the terminate calls.

This will hopefully help with a race condition when you have lots of Nomad / k8s workers, where currently, as you terminate instances, you can have them call drain on themselves as they process their terminate hook, and then some jobs could be rescheduled to nodes that are about to start draining rather than the brand new nodes. While this can still happen if we get rid of the 15s sleep between terminate calls, it should make it much narrower, especially when you have lots of workers in a cluster.