### PR TITLE
This commit replaces calls to bintray

### DIFF
--- a/bouncerw
+++ b/bouncerw
@@ -36,14 +36,14 @@ download() {
     echo "BOUNCER_VERSION is not set. Looking for the latest bouncer release..."
     # Terraform Enterprise environment doesn't have jq, replace with this once it does:
     # export BOUNCER_VERSION=$(curl -s "https://api.bintray.com/packages/palantir/releases/bouncer" | jq -r '.latest_version')
-    BOUNCER_VERSION=$(curl -s "https://api.bintray.com/packages/palantir/releases/bouncer" | grep -Eoh '"latest_version":"\S*?"' | cut -d ':' -f 2 | cut -d ',' -f 1 | sed 's/"//g')
+    BOUNCER_VERSION=$(curl -s https://api.github.com/repos/palantir/bouncer/releases/latest | jq | grep "tag_name" | sed 's/.\(.*\)/\1/' | sed 's/\(.*\)./\1/' | tr -d '"' | sed "s/.*v//")
     export BOUNCER_VERSION
   fi
   # Strip a leading 'v' if someone adds one, or one winds-up there somehow
   BOUNCER_VERSION="${BOUNCER_VERSION//v}"
   export BOUNCER_VERSION
   echo "Installing bouncer version ${BOUNCER_VERSION}"
-  wget -q -O bouncer.tgz "https://palantir.bintray.com/releases/com/palantir/bouncer/bouncer/${BOUNCER_VERSION}/bouncer-${BOUNCER_VERSION}-linux-amd64.tgz"
+  wget -q -O bouncer.tgz "https://github.com/palantir/bouncer/releases/download/v${BOUNCER_VERSION}/bouncer-${BOUNCER_VERSION}-linux-amd64.tgz"
   tar -xzf bouncer.tgz
   chmod 755 ./bouncer
 }


### PR DESCRIPTION
Calls to bintray for version are failing causing the package download
to subsequently fail. This removes those calls to bintray in favor of
calls to github.