### PR TITLE
add fast-full mode for simultaneous stop of full roll nodes.

### DIFF
--- a/bouncer/runner.go
+++ b/bouncer/runner.go
@@ -30,6 +30,7 @@ import (
 type RunnerOpts struct {
 	Noop            bool
 	Force           bool
+	Fast            bool
 	BatchSize       *int32
 	AsgString       string
 	CommandString   string

--- a/cmd/full.go
+++ b/cmd/full.go
@@ -48,6 +48,7 @@ var fullCmd = &cobra.Command{
 		force := viper.GetBool("full.force")
 		termHook := viper.GetString("terminate-hook")
 		pendHook := viper.GetString("pending-hook")
+		fast := viper.GetBool("full.fast")
 		timeout := timeoutFromViper()
 
 		log.Debugf("Binding vars, got %+v %+v %+v %+v", asgsString, noop, version, commandString)
@@ -58,6 +59,7 @@ var fullCmd = &cobra.Command{
 		opts := bouncer.RunnerOpts{
 			Noop:            noop,
 			Force:           force,
+			Fast:            fast,
 			AsgString:       asgsString,
 			CommandString:   commandString,
 			DefaultCapacity: &defCap,
@@ -110,6 +112,12 @@ func init() {
 
 	fullCmd.Flags().BoolP("force", "f", false, "Force all nodes to be recycled, even if they're running the latest launch config")
 	err = viper.BindPFlag("full.force", fullCmd.Flags().Lookup("force"))
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "Binding PFlag 'force' to viper var 'full.force' failed: %s"))
+	}
+
+	fullCmd.Flags().BoolP("fast", "", false, "Bring down all nodes simultaneously for a faster bounce cycle")
+	err = viper.BindPFlag("full.fast", fullCmd.Flags().Lookup("fast"))
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "Binding PFlag 'force' to viper var 'full.force' failed: %s"))
 	}


### PR DESCRIPTION
I have a service which needs the one-by-one roll-in of hosts for major patches - we need to allow the first host to come up fully before adding further nodes, but the previous version's hosts can come down concurrently without creating issues.