### PR TITLE
Support immutable publishing for artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,11 @@ name: Build
 on:
   push:
     branches: [master]
-    tags-ignore:
-      - '**'
+    tags:
+      - 'v[0-9]*'
 
   pull_request:
     branches: [master]
-
-  release:
-    types: [published]
 
 jobs:
   Verify:
@@ -95,7 +92,7 @@ jobs:
     #
 
     - name: Publish release assets
-      if: ${{ github.event_name == 'release' }}
+      if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
       run: ./godelw publish github --add-v-prefix --api-url=${GITHUB_API_URL} --user=palantir --repository=bouncer --token=${{ secrets.GITHUB_TOKEN }}
 
   ci-all:

--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -1,0 +1,12 @@
+version: 3
+
+options:
+  # Remove '[skip ci]' from Autorelease commit messages so the release tag push triggers the
+  # publish-godel-artifacts workflow. GitHub Actions honors '[skip ci]' on the tagged commit.
+  disable_skip_ci: true
+
+# Create the GitHub release as a draft so the publish-godel-artifacts workflow can upload the dist
+# artifacts and then finalize (un-draft) the release. GitHub's immutable-releases feature rejects
+# asset uploads to a release once it has been published.
+github_releases:
+  draft: true


### PR DESCRIPTION
Similar rationale and reasoning to https://github.com/palantir/policy-bot/pull/1330.

After enabling immutable publishing, we forgot to update bouncer.